### PR TITLE
optee_vela: add build support for SIM platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ CSRCS += compat/trace_ext.c
 CSRCS += compat/ts_manager.c
 CSRCS += compat/user_access.c
 CSRCS += compat/user_mode_ctx.c
+CSRCS += compat/user_ta_entry_dummy.c
 CSRCS += compat/vm.c
 
 ifneq ($(CONFIG_OPTEE_RPMB_FS),)

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ ifeq ($(CONFIG_ARCH_ARM64),y)
 CFLAGS += -DARM64
 else ifeq ($(CONFIG_ARCH_ARM),y)
 CFLAGS += -DARM32
+else ifeq ($(CONFIG_ARCH_SIM),y)
+CFLAGS += -DARM32
 endif
 
 CFLAGS += -DCFG_CORE_DYN_SHM

--- a/compat/malloc.c
+++ b/compat/malloc.c
@@ -17,43 +17,57 @@
  */
 
 #include <malloc.h>
-#include <stdlib.h>
 #include <nuttx/mm/mm.h>
+#include <stdlib.h>
 
-void *raw_malloc(size_t hdr_size, size_t ftr_size, size_t pl_size,
-		 struct malloc_ctx *ctx)
+void* raw_malloc(size_t hdr_size, size_t ftr_size, size_t pl_size,
+    struct malloc_ctx* ctx)
 {
-	return malloc(pl_size);
+    return malloc(pl_size);
 }
 
-void raw_free(void *ptr, struct malloc_ctx *ctx, bool wipe)
+void raw_free(void* ptr, struct malloc_ctx* ctx, bool wipe)
 {
-	free(ptr);
+    free(ptr);
 }
 
-void *raw_calloc(size_t hdr_size, size_t ftr_size, size_t pl_nmemb,
-		 size_t pl_size, struct malloc_ctx *ctx)
+void* raw_calloc(size_t hdr_size, size_t ftr_size, size_t pl_nmemb,
+    size_t pl_size, struct malloc_ctx* ctx)
 {
-	return calloc(pl_nmemb, ftr_size);
+    return calloc(pl_nmemb, ftr_size);
 }
 
-bool raw_malloc_buffer_overlaps_heap(struct malloc_ctx *ctx,
-				     void *buf, size_t len)
+bool raw_malloc_buffer_overlaps_heap(struct malloc_ctx* ctx,
+    void* buf, size_t len)
 {
-	return umm_heapmember(buf);
+    return umm_heapmember(buf);
 }
 
-bool malloc_buffer_is_within_alloced(void *buf, size_t len)
+bool malloc_buffer_is_within_alloced(void* buf, size_t len)
 {
-	return umm_heapmember(buf);
+    return umm_heapmember(buf);
 }
 
-void free_wipe(void *ptr)
+void free_wipe(void* ptr)
 {
-	raw_free(ptr, NULL, true);
+    raw_free(ptr, NULL, true);
 }
 
-bool malloc_buffer_overlaps_heap(void *buf, size_t len)
+bool malloc_buffer_overlaps_heap(void* buf, size_t len)
 {
-	return umm_heapmember(buf);
+    return umm_heapmember(buf);
 }
+
+void malloc_add_pool(void* buf, size_t len)
+{
+    raw_malloc_add_pool(NULL, buf, len);
+}
+
+size_t raw_malloc_get_ctx_size(void)
+{
+    return sizeof(struct malloc_ctx);
+}
+
+void raw_malloc_init_ctx(struct malloc_ctx* ctx) { }
+
+void raw_malloc_add_pool(struct malloc_ctx* ctx, void* buf, size_t len) { }

--- a/compat/user_ta_entry_dummy.c
+++ b/compat/user_ta_entry_dummy.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2020-2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <kernel/user_ta.h>
+#include <tee_internal_api.h>
+#include <trace.h>
+#include <user_ta_header.h>
+
+#include <stdlib.h>
+
+/* a dummy ta_head implementation  */
+const struct ta_head ta_head = {
+    .uuid = {},
+    .stack_size = 0,
+    .flags = 0,
+    .depr_entry = UINT64_MAX,
+};
+
+uint8_t ta_heap[1];
+
+const size_t ta_heap_size = sizeof(ta_heap);
+
+void __utee_tcb_init(void) { }
+
+int tahead_get_trace_level(void)
+{
+    return TRACE_INFO;
+}
+
+TEE_Result TEE_GetPropertyAsU32(TEE_PropSetHandle propsetOrEnumerator,
+    const char* name, uint32_t* value)
+{
+    return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result TA_CreateEntryPoint(void)
+{
+    return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+void TA_DestroyEntryPoint(void) { }
+
+TEE_Result TA_OpenSessionEntryPoint(uint32_t __unused param_types,
+    TEE_Param __unused params[4],
+    void** tee_session)
+{
+    return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+void TA_CloseSessionEntryPoint(void* tee_session) { }
+
+TEE_Result TA_InvokeCommandEntryPoint(void* tee_session, uint32_t cmd,
+    uint32_t ptypes,
+    TEE_Param params[TEE_NUM_PARAMS])
+{
+    return TEE_ERROR_NOT_IMPLEMENTED;
+}


### PR DESCRIPTION
1. add bget malloc compat implementation to build with SIM(x86_64) platform
2. add user_ta_entry_compat implementation to build with SIM(x86_64) platform
3. add ARCH_SIM flag support in tee to build with SIM(x86_64) platform